### PR TITLE
:wrench: Set Jest coverage threshold to 100%

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,14 @@
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/src/polyfills"
-    ]
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 100,
+        "functions": 100,
+        "lines": 100,
+        "statements": 100
+      }
+    }
   }
 }


### PR DESCRIPTION
`npm run test` will now fail if the coverage is under 100%