### PR TITLE
:wrench: accept async token function

### DIFF
--- a/src/apis/fetch.test.js
+++ b/src/apis/fetch.test.js
@@ -6,7 +6,7 @@ jest.mock('cross-fetch', () => jest.fn())
 jest.mock('../polyfills/Blob')
 
 describe('fetch', () => {
-  const token = () => 'my-token'
+  const token = async () => 'my-token'
 
   beforeEach(() => {
     crossFetch.mockReset()

--- a/src/apis/fetch.ts
+++ b/src/apis/fetch.ts
@@ -5,7 +5,7 @@ export class FetchError extends Error {
   public error!: JSON
 }
 
-export const fetch = (token: Function): Function => (
+export const fetch = (token: Function): Function => async (
   url: string,
   body: any = null,
   options: { method?: string; headers?: any; raw?: boolean } = {}
@@ -20,7 +20,7 @@ export const fetch = (token: Function): Function => (
     method: method || (body ? 'POST' : 'GET'),
     body,
     headers: {
-      authorization: `Bearer ${token()}`,
+      authorization: `Bearer ${await token()}`,
       'Content-Type': 'application/json',
       ...headers
     },


### PR DESCRIPTION
This makes easy to work with https://github.com/googleapis/google-auth-library-nodejs
ex:
```javascript
async function token(){
  const auth = new OAuth2Client(
      keys.web.client_id,
      keys.web.client_secret
    );
  auth.setCredentials({refresh_token})
  return (await auth.getAccessToken()).token
}
const mustaches = new Mustaches({ token })
```

