### PR TITLE
Fix bug where contentPlaceholder.output is null

### DIFF
--- a/src/documentProcessing/buildUpdates/buildUpdates.ts
+++ b/src/documentProcessing/buildUpdates/buildUpdates.ts
@@ -9,7 +9,7 @@ const buildUpdates = (placeholders: Placeholder[]): Request[] => {
     if (placeholder.type == 'content') {
       const contentPlaceholder = placeholder as ContentPlaceholder
       // Image
-      if (contentPlaceholder.output.url) {
+      if (contentPlaceholder.output && contentPlaceholder.output.url) {
         const output = contentPlaceholder.output
         // Insert image
         updates.push({


### PR DESCRIPTION
When using this library I get "Cannot read property url of null" as an error.

I'm not sure why exactly this occurs, but this simple check seems to fix it.