### PR TITLE
🐛  Fix wrong formatter param splitting

### DIFF
--- a/src/documentProcessing/resolvePlaceholders/computeContent/pipe/pipe.ts
+++ b/src/documentProcessing/resolvePlaceholders/computeContent/pipe/pipe.ts
@@ -25,7 +25,7 @@ export default (
 
   let typedParams = []
   if (matches.groups.params) {
-    typedParams = normalizeParams(matches.groups.params.split(','), data, options)
+    typedParams = normalizeParams(matches.groups.params.split(/,(?=(?:[^“”"']|[“"'][^“”"']*[”"'])*$)/), data, options)
   }
 
   return formatter(value, ...typedParams)


### PR DESCRIPTION
## Resolves Issues
fixes #44 

## What does this PR do?
This PR replaces the simple "split by comma" functionality into a split that uses a regex so we don't split by commas that are nested within encapsulated strings see #44 

@Errorname Sorry but I didn't setup the local development environment and therefore neither ran the linters on this commit nor did I at all test it with the typescript syntax. I only tested it by directly editing the js source code within the node_modules folder within my backend project. So I apologize for any linter or syntax errors but I thought with such a small change you would forgive me 😉 

Happy to hear your feedback

PS: I'm also happy to explain this RegEx. I'm quite ok with them but this lookaheads are also for me a headscratcher. I used this website to test my regex https://regexr.com/5cucg