### PR TITLE
:sparkles: Allow for Multi Word root Variable names in placeholders

### DIFF
--- a/src/placeholders/syntax/parser.ts
+++ b/src/placeholders/syntax/parser.ts
@@ -11,7 +11,7 @@ const matchRegex = (str: string, regexp: RegExp) => {
 const parseExpression = (str: string): string[] => {
   const [token, rest] = matchRegex(
     str,
-    /^(\w+(?:(?:\.\w+)|(?:\[.*\])|(?:\(.*\)))*)(?:\s*\|\s*(.+))?$/
+    /^(\w+(?:(?:\.\w+)|(?:\[.*\])|(?:\(.*\))|(?: \w+))*)(?:\s*\|\s*(.+))?$/
   )
 
   if (rest) {
@@ -23,7 +23,7 @@ const parseExpression = (str: string): string[] => {
 const parseToken = (str: string): PropertyToken | undefined => {
   if (!str) return undefined
 
-  const [name, rest] = matchRegex(str, /^(\w+)(.*)$/)
+  const [name, rest] = matchRegex(str, /^([\w ]+)(.*)$/)
 
   return {
     type: 'property',


### PR DESCRIPTION
# What
Allows the usage of placeholders like this `{{ Multi Word Placeholder }}`

## Not tested
Not tested are usages like these 
- `{{ Placeholder.Multi Word Subproperty }}`
- `{{ Placeholder.Multi Word Subfunction() }}`
- `{{ Placeholder[Multi Word Subproperty] }}`
- `{{ Placeholder[Multi Word Subfunction]() }}`
- `{{ Placeholder | multi word formatter }}`
- `{{ Placeholder | multi word formatter(1,2,3) }}`

I don't have time today to test the cases from the "Not tested" category. Or maybe you can help me here. Otherwise I'd have to see when I have the time to test it, but I definitely like the feature itself even if only the one case is covered