### PR TITLE
:bug: Fix not Replace Behaviour on not provided replace value with applied Formatters

### DIFF
--- a/src/placeholders/syntax/compute.ts
+++ b/src/placeholders/syntax/compute.ts
@@ -26,7 +26,9 @@ const compute = (
       evaluateToken(part, null, { ...options.formatters, ...data }, true)
     )
 
-    return evaluatedParts.reduce((prev, formatter) => formatter(prev))
+    return typeof evaluatedParts[0] !== 'undefined'
+      ? evaluatedParts.reduce((prev, formatter) => formatter(prev))
+      : undefined
   } catch (error) {
     if (options.strict) {
       throw error


### PR DESCRIPTION
# What
If no replace value is provided we also wan't to return undefined so that we don't replace the placeholder.
This wasn't the case if the not provided placeholder had also formatters applied. This commit corrects this behaviour