### PR TITLE
fix: fetch-blob@1.0.7 not support node.js 16 lts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/errorname/google-docs-mustaches#readme",
   "dependencies": {
     "cross-fetch": "^3.0.4",
-    "fetch-blob": "^1.0.5"
+    "fetch-blob": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.3",


### PR DESCRIPTION
fetch-blob@1.0.7: The engine "node" is incompatible with this module. Expected version "^10.17.0"